### PR TITLE
Xgboost metrics

### DIFF
--- a/corebehrt/constants/causal/paths.py
+++ b/corebehrt/constants/causal/paths.py
@@ -6,7 +6,6 @@ TRAIN_MLP_CFG = "train_mlp_config.yaml"
 TRAIN_XGB_CFG = "train_xgb_config.yaml"
 ESTIMATE_CFG = "estimate_config.yaml"
 ENCODINGS_FILE = "encodings.pt"
-COHORT_ADVANCED_CFG = "cohort_advanced_config.yaml"
 # Files
 PREDICTIONS_FILE = "predictions_and_targets.csv"
 CALIBRATED_PREDICTIONS_FILE = "predictions_and_targets_calibrated.csv"

--- a/corebehrt/main_causal/select_cohort_advanced.py
+++ b/corebehrt/main_causal/select_cohort_advanced.py
@@ -76,7 +76,8 @@ def main(config_path: str):
 
     logger.info("Loading criteria config")
     criteria_config = load_config(criteria_config_path)
-
+    # Write criteria config to output directory
+    cfg.save_to_yaml(join(save_path, "criteria_config.yaml"))
     logger.info("Extracting criteria")
     criteria_df = extract_and_save_criteria(
         meds_path, index_dates, criteria_config, save_path, splits, pids

--- a/corebehrt/main_causal/train_xgb.py
+++ b/corebehrt/main_causal/train_xgb.py
@@ -52,7 +52,7 @@ def main_train(config_path: str):
 
         # Train model (validation data not used in training anymore)
         logger.info("Training XGBoost model...")
-        model, scores = train_xgb_model(
+        model = train_xgb_model(
             X_train,
             y_train,
             X_val,

--- a/corebehrt/main_causal/train_xgb.py
+++ b/corebehrt/main_causal/train_xgb.py
@@ -1,3 +1,4 @@
+import json
 import logging
 import os
 from os.path import join
@@ -8,7 +9,12 @@ from corebehrt.constants.causal.paths import CALIBRATED_PREDICTIONS_FILE
 from corebehrt.constants.data import TRAIN_KEY, VAL_KEY
 from corebehrt.functional.setup.args import get_args
 from corebehrt.main_causal.helper.calibrate_xgb import calibrate_predictions
-from corebehrt.main_causal.helper.train_xgb import setup_xgb_params, train_xgb_model
+from corebehrt.main_causal.helper.train_xgb import (
+    calculate_metrics,
+    initialize_metrics,
+    setup_xgb_params,
+    train_xgb_model,
+)
 from corebehrt.modules.setup.config import load_config
 from corebehrt.modules.setup.directory_causal import CausalDirectoryPreparer
 from corebehrt.modules.trainer.data_module import EncodedDataModule
@@ -46,7 +52,7 @@ def main_train(config_path: str):
 
         # Train model (validation data not used in training anymore)
         logger.info("Training XGBoost model...")
-        model = train_xgb_model(
+        model, scores = train_xgb_model(
             X_train,
             y_train,
             X_val,
@@ -58,6 +64,13 @@ def main_train(config_path: str):
             scoring=cfg.model.get("scoring", "neg_log_loss"),
             early_stopping_rounds=cfg.model.get("early_stopping_rounds", 10),
         )
+
+        logger.info("Validation metrics:")
+        metrics = initialize_metrics(cfg.model.get("metrics", None))
+        scores = calculate_metrics(model, X_val, y_val, metrics)
+        # Save scores dictionary
+        with open(join(fold_folder, "scores.json"), "w") as f:
+            json.dump(scores, f, indent=4)
 
         # Save model
         model.save_model(join(fold_folder, "model.json"))

--- a/corebehrt/modules/setup/directory_causal.py
+++ b/corebehrt/modules/setup/directory_causal.py
@@ -98,8 +98,10 @@ class CausalDirectoryPreparer(DirectoryPreparer):
         )
         try:
             self.write_config("trained_mlp", source="cohort", name=COHORT_CFG)
-        except:
-            logger.warning("No cohort config found, skipping cohort config write.")
+        except Exception as e:
+            logger.warning(
+                f"No cohort config found, skipping cohort config write. Error: {e}"
+            )
         self.write_config("trained_mlp", name=TRAIN_MLP_CFG)
 
     def setup_train_xgb(self) -> None:
@@ -121,8 +123,10 @@ class CausalDirectoryPreparer(DirectoryPreparer):
         self.write_config(out, source="calibrated_predictions", name=CALIBRATE_CFG)
         try:
             self.write_config(out, source="cohort", name=COHORT_CFG)
-        except:
-            logger.warning("No cohort config found, skipping cohort config write.")
+        except Exception as e:
+            logger.warning(
+                f"No cohort config found, skipping cohort config write. Error: {e}"
+            )
         self.write_config(out, name=TRAIN_XGB_CFG)
 
     def setup_estimate(self) -> None:

--- a/corebehrt/modules/setup/directory_causal.py
+++ b/corebehrt/modules/setup/directory_causal.py
@@ -96,7 +96,10 @@ class CausalDirectoryPreparer(DirectoryPreparer):
         self.write_config(
             "trained_mlp", source="calibrated_predictions", name=CALIBRATE_CFG
         )
-        self.write_config("trained_mlp", source="cohort", name=COHORT_CFG)
+        try:
+            self.write_config("trained_mlp", source="cohort", name=COHORT_CFG)
+        except:
+            logger.warning("No cohort config found, skipping cohort config write.")
         self.write_config("trained_mlp", name=TRAIN_MLP_CFG)
 
     def setup_train_xgb(self) -> None:
@@ -116,7 +119,10 @@ class CausalDirectoryPreparer(DirectoryPreparer):
         # Write config in output directory.
         self.write_config(out, source="encoded_data", name=ENCODE_CFG)
         self.write_config(out, source="calibrated_predictions", name=CALIBRATE_CFG)
-        self.write_config(out, source="cohort", name=COHORT_CFG)
+        try:
+            self.write_config(out, source="cohort", name=COHORT_CFG)
+        except:
+            logger.warning("No cohort config found, skipping cohort config write.")
         self.write_config(out, name=TRAIN_XGB_CFG)
 
     def setup_estimate(self) -> None:

--- a/corebehrt/modules/setup/directory_causal.py
+++ b/corebehrt/modules/setup/directory_causal.py
@@ -7,11 +7,11 @@ from corebehrt.constants.causal.paths import (
     SIMULATE_CFG,
     TRAIN_MLP_CFG,
     TRAIN_XGB_CFG,
-    COHORT_ADVANCED_CFG,
 )
 from corebehrt.constants.paths import COHORT_CFG, FINETUNE_CFG, PRETRAIN_CFG
 from corebehrt.modules.setup.config import Config
 from corebehrt.modules.setup.directory import DirectoryPreparer
+
 
 logger = logging.getLogger(__name__)  # Get the logger for this module
 
@@ -157,4 +157,4 @@ class CausalDirectoryPreparer(DirectoryPreparer):
         self.check_directory("meds")
         # Create output directories
         self.create_directory("cohort_advanced")
-        self.write_config("cohort_advanced", name=COHORT_ADVANCED_CFG)
+        self.write_config("cohort", name=COHORT_CFG)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added standardized metric initialization and calculation for XGBoost model validation, with results saved as a formatted JSON file.
  - Validation metrics (such as ROC AUC and PR AUC) are now computed and logged after model training.

- **Bug Fixes**
  - Improved error handling when writing cohort configuration files, preventing failures if configuration is missing.

- **Other Improvements**
  - Criteria configuration is now saved as a YAML file during cohort selection.
  - Updated documentation to clarify early stopping parameter usage in model training.
  - Removed obsolete cohort advanced configuration constant to streamline configuration management.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->