### PR TITLE
Merge/may7

### DIFF
--- a/corebehrt/azure/README.md
+++ b/corebehrt/azure/README.md
@@ -179,7 +179,7 @@ FINETUNE = PipelineMeta(
     name="FINETUNE",
     help="Run the finetune pipeline.",
     inputs=[
-        PipelineArg(name="data",        help="Path to the raw input data.",    required=True),
+        PipelineArg(name="data",        help="Path to the raw input data.",    required=False),
         PipelineArg(name="features",    help="Path to the features data.",       required=True),
         PipelineArg(name="tokenized",   help="Path to the tokenized data.",      required=True),
         PipelineArg(name="pretrain_model", help="Path to the pretrained model.", required=True),
@@ -219,7 +219,7 @@ With that in place, your CLI will support:
 python -m corebehrt.azure pipeline FINETUNE \
                CPU-20-LP \
                path/to/config/dir \
-               --data /path/to/data \
+               [--data /path/to/data] \ # Only required if outcomes are not provided
                --features /path/to/features \
                --tokenized /path/to/tokenized \
                --pretrain_model /models/base \

--- a/corebehrt/azure/pipelines/FINETUNE.py
+++ b/corebehrt/azure/pipelines/FINETUNE.py
@@ -1,5 +1,5 @@
 """
-Finetune pipeline implementation.
+Finetune pipeline implementation with proper handling of optional inputs.
 """
 
 from corebehrt.azure.pipelines.base import PipelineMeta, PipelineArg
@@ -8,7 +8,11 @@ FINETUNE = PipelineMeta(
     name="FINETUNE",
     help="Run the finetune pipeline.",
     inputs=[
-        PipelineArg(name="data", help="Path to the raw input data.", required=True),
+        PipelineArg(
+            name="data",
+            help="Path to the raw input data. Only required if outcomes is not provided.",
+            required=False,
+        ),
         PipelineArg(name="features", help="Path to the features data.", required=True),
         PipelineArg(
             name="tokenized", help="Path to the tokenized data.", required=True
@@ -30,24 +34,41 @@ def create(component: callable):
     name (name of component if different from type of job).
     """
     from azure.ai.ml import dsl, Input
+    from typing import Dict, Any
 
-    @dsl.pipeline(name="finetune_pipeline", description="Finetune CoreBEHRT pipeline")
-    def pipeline(
-        data: Input,
+    # Define a factory function that returns the appropriate pipeline
+    def pipeline_factory(**kwargs: Dict[str, Any]):
+        # Check if outcomes is provided
+        has_outcomes = "outcomes" in kwargs and kwargs["outcomes"] is not None
+
+        if has_outcomes:
+            # With outcomes, we don't need data
+            if "data" in kwargs:
+                del kwargs["data"]
+            return _pipeline_with_outcomes(**kwargs)
+        else:
+            # Without outcomes, we need data
+            if "data" not in kwargs:
+                raise ValueError(
+                    "'data' input is required when 'outcomes' is not provided"
+                )
+
+            # Remove outcomes from kwargs if it exists but is None
+            if "outcomes" in kwargs:
+                del kwargs["outcomes"]
+            return _pipeline_without_outcomes(**kwargs)
+
+    @dsl.pipeline(
+        name="finetune_with_outcomes",
+        description="Finetune CoreBEHRT pipeline with provided outcomes",
+    )
+    def _pipeline_with_outcomes(
         features: Input,
         tokenized: Input,
         pretrain_model: Input,
-        outcomes: Input = None,
+        outcomes: Input,
     ) -> dict:
-        if outcomes is None:
-            create_outcomes = component(
-                "create_outcomes",
-            )(
-                data=data,
-                features=features,
-            )
-            outcomes = create_outcomes.outputs.outcomes
-
+        # Using provided outcomes
         select_cohort = component(
             "select_cohort",
         )(
@@ -76,4 +97,51 @@ def create(component: callable):
             "model": finetune.outputs.model,
         }
 
-    return pipeline
+    @dsl.pipeline(
+        name="finetune_without_outcomes",
+        description="Finetune CoreBEHRT pipeline with auto-created outcomes",
+    )
+    def _pipeline_without_outcomes(
+        data: Input,
+        features: Input,
+        tokenized: Input,
+        pretrain_model: Input,
+    ) -> dict:
+        # Create outcomes internally
+        create_outcomes = component(
+            "create_outcomes",
+        )(
+            data=data,
+            features=features,
+        )
+
+        select_cohort = component(
+            "select_cohort",
+        )(
+            features=features,
+            outcomes=create_outcomes.outputs.outcomes,
+        )
+
+        prepare_finetune = component(
+            "prepare_training_data",
+            name="prepare_finetune",
+        )(
+            features=features,
+            tokenized=tokenized,
+            cohort=select_cohort.outputs.cohort,
+            outcomes=create_outcomes.outputs.outcomes,
+        )
+
+        finetune = component(
+            "finetune_cv",
+        )(
+            prepared_data=prepare_finetune.outputs.prepared_data,
+            pretrain_model=pretrain_model,
+        )
+
+        return {
+            "model": finetune.outputs.model,
+        }
+
+    # Return the factory function instead of a direct pipeline
+    return pipeline_factory

--- a/tests/test_main/test_finetune.py
+++ b/tests/test_main/test_finetune.py
@@ -31,7 +31,7 @@ class TestFinetune(TestMainScript):
                     "batch_size": 128,
                     "val_batch_size": 128,
                     "effective_batch_size": 128,
-                    "epochs": 30,
+                    "epochs": 10,
                     "info": True,
                     "gradient_clip": {
                         "clip_value": 1.0,


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - The finetune pipeline now allows the `data` input to be optional if `outcomes` are provided directly, offering more flexibility in how the pipeline can be invoked.

- **Documentation**
  - Updated the README to clarify that the `--data` argument is now optional and only required if `outcomes` are not specified.

- **Tests**
  - Reduced the number of training epochs in finetune tests to improve test efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->