### PR TITLE
Add select_cohort_full component and update pipelines

### DIFF
--- a/corebehrt/azure/components/select_cohort_full.py
+++ b/corebehrt/azure/components/select_cohort_full.py
@@ -1,0 +1,19 @@
+from corebehrt.azure.util import job
+
+INPUTS = {
+    "features": {"type": "uri_folder"},
+    "meds": {"type": "uri_folder"},
+    "exposures": {"type": "uri_folder"},
+}
+OUTPUTS = {"cohort": {"type": "uri_folder"}}
+
+
+if __name__ == "__main__":
+    from corebehrt.main_causal import select_cohort_full
+
+    job.run_main(
+        "select_cohort_full",
+        select_cohort_full.main,
+        INPUTS,
+        OUTPUTS,
+    )

--- a/corebehrt/azure/main/job.py
+++ b/corebehrt/azure/main/job.py
@@ -51,6 +51,7 @@ def add_parser(subparsers) -> None:
             "get_code_counts",
             "map_rare_codes",
             "select_cohort_advanced",
+            "select_cohort_full",
             "evaluate_finetune",
             "extract_criteria",
             "get_stats",

--- a/corebehrt/azure/pipelines/FINETUNE_ESTIMATE.py
+++ b/corebehrt/azure/pipelines/FINETUNE_ESTIMATE.py
@@ -1,22 +1,17 @@
 """
-Estimate pipeline implementation with optional outcomes, exposures, and cohort.
+Estimate pipeline implementation with optional cohort.
 """
 
 from typing import Any, Dict
 
 from corebehrt.azure.pipelines.base import PipelineArg, PipelineMeta
-from corebehrt.constants.causal.data import OUTCOMES, EXPOSURES, COHORT, DATA
-
+from corebehrt.constants.causal.data import COHORT
 
 FINETUNE_ESTIMATE = PipelineMeta(
     name="FINETUNE_ESTIMATE",
     help="Run the estimate pipeline.",
     inputs=[
-        PipelineArg(
-            name=DATA,
-            help="Path to the raw input data. Required if outcomes, exposures or cohort is not provided.",
-            required=False,
-        ),
+        PipelineArg(name="meds", help="Path to the raw input data.", required=True),
         PipelineArg(name="features", help="Path to the features data.", required=True),
         PipelineArg(
             name="tokenized", help="Path to the tokenized data.", required=True
@@ -24,19 +19,13 @@ FINETUNE_ESTIMATE = PipelineMeta(
         PipelineArg(
             name="pretrain_model", help="Path to the pretrained model.", required=True
         ),
+        PipelineArg(name="outcomes", help="Path to the outcomes data.", required=True),
         PipelineArg(
-            name="outcomes",
-            help="Path to the outcomes data. If not provided, will be created from data.",
-            required=False,
-        ),
-        PipelineArg(
-            name="exposures",
-            help="Path to the exposures data. Used to train propensity model. If not provided, will be created from data.",
-            required=False,
+            name="exposures", help="Path to the exposures data.", required=True
         ),
         PipelineArg(
             name="cohort",
-            help="Path to the cohort data. If not provided, will be created from features and exposures.",
+            help="Path to the cohort data. If not provided, will be created from meds, features and exposures.",
             required=False,
         ),
     ],
@@ -55,6 +44,7 @@ def create(component: callable):
 
     # Core implementation of pipeline steps - not a pipeline itself
     def _common_pipeline_steps(
+        meds: Input,
         features: Input,
         tokenized: Input,
         pretrain_model: Input,
@@ -66,313 +56,105 @@ def create(component: callable):
         # Get cohort from input or generate it
         if cohort is None:
             select_cohort = component(
-                "select_cohort",
+                "select_cohort_full",
             )(
+                meds=meds,
                 features=features,
-                outcomes=exposures,
+                exposures=exposures,
             )
             resolved_cohort = select_cohort.outputs.cohort
         else:
             resolved_cohort = cohort
 
-        prepare_finetune = component(
-            "prepare_training_data",
-            name="prepare_finetune",
+        prepare_finetune_exp_y = component(
+            "prepare_ft_exp_y",
+            name="prepare_finetune_exp_y",
         )(
             features=features,
             tokenized=tokenized,
             cohort=resolved_cohort,
-            outcomes=exposures,
-        )
-
-        finetune = component(
-            "finetune_cv",
-        )(
-            prepared_data=prepare_finetune.outputs.prepared_data,
-            pretrain_model=pretrain_model,
-        )
-        calibrate = component(
-            "calibrate",
-        )(
-            finetune_model=finetune.outputs.model,
-        )
-        encode = component(
-            "encode",
-        )(
-            finetune_model=finetune.outputs.model,
-            prepared_data=prepare_finetune.outputs.prepared_data,
-        )
-
-        train_mlp = component(
-            "train_mlp",
-        )(
-            encoded_data=encode.outputs.encoded_data,
-            calibrated_predictions=calibrate.outputs.calibrated_predictions,
-            cohort=resolved_cohort,
+            exposures=exposures,
             outcomes=outcomes,
         )
 
+        finetune_exp_y = component(
+            "finetune_exp_y",
+        )(
+            prepared_data=prepare_finetune_exp_y.outputs.prepared_data,
+            pretrain_model=pretrain_model,
+        )
+        calibrate_exp_y = component(
+            "calibrate_exp_y",
+        )(
+            finetune_model=finetune_exp_y.outputs.model,
+        )
         estimate = component(
             "estimate",
         )(
-            exposure_predictions=calibrate.outputs.calibrated_predictions,
-            outcome_predictions=train_mlp.outputs.trained_mlp,
+            calibrated_predictions=calibrate_exp_y.outputs.calibrated_predictions,
         )
 
         return {
             "estimate": estimate.outputs.estimate,
-            "ps_model": finetune.outputs.model,
-            "outcome_mlp": train_mlp.outputs.trained_mlp,
-            "encoded_data": encode.outputs.encoded_data,
-            "calibrated_predictions": calibrate.outputs.calibrated_predictions,
+            "calibrated_predictions": calibrate_exp_y.outputs.calibrated_predictions,
         }
 
-    # Define all pipeline variants using a dictionary
+    # Define the two pipeline variants (with and without cohort)
     pipeline_configs = {}
 
-    # 1. All inputs provided (outcomes, exposures, cohort)
+    # 1. All inputs provided (including cohort)
     @dsl.pipeline(
-        name="ft_estimate_w_out_exp_cohort",
-        description="Pipeline with provided outcomes, exposures, and cohort",
+        name="ft_estimate_w_cohort",
+        description="Pipeline with provided cohort",
     )
-    def _pipeline_all(
-        features: Input,
-        tokenized: Input,
-        pretrain_model: Input,
-        outcomes: Input,
-        exposures: Input,
-        cohort: Input,
-    ) -> dict:
-        return _common_pipeline_steps(
-            features, tokenized, pretrain_model, exposures, outcomes, cohort
-        )
-
-    pipeline_configs[(True, True, True)] = _pipeline_all
-
-    # 2. Outcomes and exposures provided (no cohort)
-    @dsl.pipeline(
-        name="ft_estimate_w_out_exp",
-        description="Pipeline with provided outcomes and exposures",
-    )
-    def _pipeline_outcomes_exposures(
-        features: Input,
-        tokenized: Input,
-        pretrain_model: Input,
-        outcomes: Input,
-        exposures: Input,
-    ) -> dict:
-        return _common_pipeline_steps(
-            features, tokenized, pretrain_model, exposures, outcomes
-        )
-
-    pipeline_configs[(True, True, False)] = _pipeline_outcomes_exposures
-
-    # 3. Outcomes and cohort provided (no exposures)
-    @dsl.pipeline(
-        name="ft_estimate_w_out_cohort",
-        description="Pipeline with provided outcomes and cohort",
-    )
-    def _pipeline_outcomes_cohort(
-        data: Input,
-        features: Input,
-        tokenized: Input,
-        pretrain_model: Input,
-        outcomes: Input,
-        cohort: Input,
-    ) -> dict:
-        create_exposures = component("create_outcomes", name="create_exposures")(
-            data=data,
-            features=features,
-        )
-        return _common_pipeline_steps(
-            features,
-            tokenized,
-            pretrain_model,
-            create_exposures.outputs.outcomes,
-            outcomes,
-            cohort,
-        )
-
-    pipeline_configs[(True, False, True)] = _pipeline_outcomes_cohort
-
-    # 4. Outcomes only provided (no exposures, no cohort)
-    @dsl.pipeline(
-        name="ft_estimate_w_out_only",
-        description="Pipeline with provided outcomes only",
-    )
-    def _pipeline_outcomes_only(
-        data: Input,
-        features: Input,
-        tokenized: Input,
-        pretrain_model: Input,
-        outcomes: Input,
-    ) -> dict:
-        create_exposures = component("create_outcomes", name="create_exposures")(
-            data=data,
-            features=features,
-        )
-        return _common_pipeline_steps(
-            features,
-            tokenized,
-            pretrain_model,
-            create_exposures.outputs.outcomes,
-            outcomes,
-        )
-
-    pipeline_configs[(True, False, False)] = _pipeline_outcomes_only
-
-    # 5. Exposures and cohort provided (no outcomes)
-    @dsl.pipeline(
-        name="ft_estimate_w_exp_cohort",
-        description="Pipeline with provided exposures and cohort",
-    )
-    def _pipeline_exposures_cohort(
-        data: Input,
+    def _pipeline_with_cohort(
+        meds: Input,
         features: Input,
         tokenized: Input,
         pretrain_model: Input,
         exposures: Input,
+        outcomes: Input,
         cohort: Input,
     ) -> dict:
-        create_outcomes = component("create_outcomes", name="create_outcomes")(
-            data=data,
-            features=features,
-        )
         return _common_pipeline_steps(
-            features,
-            tokenized,
-            pretrain_model,
-            exposures,
-            create_outcomes.outputs.outcomes,
-            cohort,
+            meds, features, tokenized, pretrain_model, exposures, outcomes, cohort
         )
 
-    pipeline_configs[(False, True, True)] = _pipeline_exposures_cohort
+    pipeline_configs[True] = _pipeline_with_cohort
 
-    # 6. Exposures only provided (no outcomes, no cohort)
+    # 2. Without cohort (will be generated)
     @dsl.pipeline(
-        name="ft_estimate_w_exp_only",
-        description="Pipeline with provided exposures only",
+        name="ft_estimate_wo_cohort",
+        description="Pipeline without cohort (will be generated)",
     )
-    def _pipeline_exposures_only(
-        data: Input,
+    def _pipeline_without_cohort(
+        meds: Input,
         features: Input,
         tokenized: Input,
         pretrain_model: Input,
         exposures: Input,
+        outcomes: Input,
     ) -> dict:
-        create_outcomes = component("create_outcomes", name="create_outcomes")(
-            data=data,
-            features=features,
-        )
         return _common_pipeline_steps(
-            features,
-            tokenized,
-            pretrain_model,
-            exposures,
-            create_outcomes.outputs.outcomes,
+            meds, features, tokenized, pretrain_model, exposures, outcomes
         )
 
-    pipeline_configs[(False, True, False)] = _pipeline_exposures_only
-
-    # 7. Cohort only provided (no outcomes, no exposures)
-    @dsl.pipeline(
-        name="ft_estimate_w_cohort_only",
-        description="Pipeline with provided cohort only",
-    )
-    def _pipeline_cohort_only(
-        data: Input,
-        features: Input,
-        tokenized: Input,
-        pretrain_model: Input,
-        cohort: Input,
-    ) -> dict:
-        create_exposures = component("create_outcomes", name="create_exposures")(
-            data=data,
-            features=features,
-        )
-        create_outcomes = component("create_outcomes", name="create_outcomes")(
-            data=data,
-            features=features,
-        )
-        return _common_pipeline_steps(
-            features,
-            tokenized,
-            pretrain_model,
-            create_exposures.outputs.outcomes,
-            create_outcomes.outputs.outcomes,
-            cohort,
-        )
-
-    pipeline_configs[(False, False, True)] = _pipeline_cohort_only
-
-    # 8. No inputs provided (create outcomes, exposures, cohort)
-    @dsl.pipeline(
-        name="ft_estimate_w_no_optional_inputs",
-        description="Pipeline creating all optional inputs",
-    )
-    def _pipeline_basic(
-        data: Input,
-        features: Input,
-        tokenized: Input,
-        pretrain_model: Input,
-    ) -> dict:
-        create_exposures = component("create_outcomes", name="create_exposures")(
-            data=data,
-            features=features,
-        )
-        create_outcomes = component("create_outcomes", name="create_outcomes")(
-            data=data,
-            features=features,
-        )
-        return _common_pipeline_steps(
-            features,
-            tokenized,
-            pretrain_model,
-            create_exposures.outputs.outcomes,
-            create_outcomes.outputs.outcomes,
-        )
-
-    pipeline_configs[(False, False, False)] = _pipeline_basic
+    pipeline_configs[False] = _pipeline_without_cohort
 
     # Factory function to select the appropriate pipeline
     def pipeline_factory(**kwargs: Dict[str, Any]):
         """
-        Creates the appropriate pipeline based on available inputs.
-
-        This factory function:
-        1. Determines which optional inputs are provided
-        2. Validates that data is available when needed
-        3. Selects the appropriate pipeline variant
-        4. Filters kwargs to match the selected pipeline's signature
+        Creates the appropriate pipeline based on whether cohort is provided.
 
         Args:
-            **kwargs: Pipeline inputs (data, features, tokenized, pretrain_model, exposures, outcomes, cohort)
+            **kwargs: Pipeline inputs (meds, features, tokenized, pretrain_model, exposures, outcomes, cohort)
         Returns:
             Configured pipeline instance
-        Raises:
-            ValueError: When data is missing but required for creating exposures/outcomes
         """
-        has_outcomes = OUTCOMES in kwargs and kwargs[OUTCOMES] is not None
-        has_exposures = EXPOSURES in kwargs and kwargs[EXPOSURES] is not None
         has_cohort = COHORT in kwargs and kwargs[COHORT] is not None
 
-        # Validate data availability when needed
-        if not (has_exposures and has_outcomes) and (
-            DATA not in kwargs or kwargs[DATA] is None
-        ):
-            missing = []
-            if not has_exposures:
-                missing.append(EXPOSURES)
-            if not has_outcomes:
-                missing.append(OUTCOMES)
-            raise ValueError(
-                f"'data' input is required when {' and '.join(missing)} {'is' if len(missing) == 1 else 'are'} not provided"
-            )
-
         # Select the appropriate pipeline based on what's provided
-        pipeline_key = (has_outcomes, has_exposures, has_cohort)
-        selected_pipeline = pipeline_configs[pipeline_key]
+        selected_pipeline = pipeline_configs[has_cohort]
 
         # Filter kwargs to only include parameters the selected pipeline accepts
         from inspect import signature

--- a/corebehrt/configs/causal/estimate/estimate.yaml
+++ b/corebehrt/configs/causal/estimate/estimate.yaml
@@ -4,9 +4,7 @@ logging:
 
 paths:
   ## INPUTS
-  exposure_predictions: ./outputs/causal/finetune/models/exp_y/calibrated/predictions_exposure # containing predictions_and_targets_calibrated.csv
-  outcome_predictions: ./outputs/causal/finetune/models/exp_y/calibrated/predictions_outcome # containing predictions_and_targets_calibrated.csv
-
+  calibrated_predictions: ./outputs/causal/finetune/models/exp_y/calibrated/
   # counterfactual_outcomes: ./outputs/causal/counterfactual_outcomes # optional
 
   ## OUTPUTS

--- a/corebehrt/modules/causal/estimate.py
+++ b/corebehrt/modules/causal/estimate.py
@@ -1,14 +1,13 @@
 from os.path import join
 from typing import Any, Dict
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 import torch
 from CausalEstimate import MultiEstimator
 from CausalEstimate.estimators import AIPW, IPW, TMLE
 from CausalEstimate.filter.propensity import filter_common_support
 from CausalEstimate.stats.stats import compute_treatment_outcome_table
-from corebehrt.constants.causal.paths import PATIENTS_FILE
 
 from corebehrt.constants.causal.data import (
     CF_PROBAS,
@@ -28,6 +27,9 @@ from corebehrt.constants.causal.paths import (
     ESTIMATE_RESULTS_FILE,
     EXPERIMENT_DATA_FILE,
     EXPERIMENT_STATS_FILE,
+    PATIENTS_FILE,
+    PREDICTIONS_DIR_EXPOSURE,
+    PREDICTIONS_DIR_OUTCOME,
     SIMULATION_RESULTS_FILE,
 )
 from corebehrt.constants.data import PID_COL
@@ -52,8 +54,19 @@ class EffectEstimator:
 
     def _set_paths(self) -> None:
         self.exp_dir = self.cfg.paths.estimate
-        self.exposure_pred_dir = self.cfg.paths.exposure_predictions
-        self.outcome_pred_dir = self.cfg.paths.outcome_predictions
+
+        if self.cfg.paths.get("exposure_predictions") is not None:
+            self.exposure_pred_dir = self.cfg.paths.exposure_predictions
+        else:
+            self.exposure_pred_dir = join(
+                self.cfg.paths.calibrated_predictions, PREDICTIONS_DIR_EXPOSURE
+            )
+        if self.cfg.paths.get("outcome_predictions") is not None:
+            self.outcome_pred_dir = self.cfg.paths.outcome_predictions
+        else:
+            self.outcome_pred_dir = join(
+                self.cfg.paths.calibrated_predictions, PREDICTIONS_DIR_OUTCOME
+            )
         self.counterfactual_outcomes_dir = self.cfg.paths.get("counterfactual_outcomes")
 
     def _get_estimation_args(self) -> Dict:

--- a/corebehrt/modules/setup/causal/directory.py
+++ b/corebehrt/modules/setup/causal/directory.py
@@ -92,8 +92,11 @@ class CausalDirectoryPreparer(DirectoryPreparer):
         self.setup_logging("estimate")
 
         # Validate and create directories
-        self.check_directory("exposure_predictions")
-        self.check_directory("outcome_predictions")
+        if self.cfg.paths.get("calibrated_predictions", False):
+            self.check_directory("calibrated_predictions")
+        else:
+            self.check_directory("exposure_predictions")
+            self.check_directory("outcome_predictions")
 
         # Optional counterfactual outcomes check
         if self.cfg.paths.get("counterfactual_outcomes", False):


### PR DESCRIPTION
- Introduced a new component `select_cohort_full` for cohort selection.
- Updated job parser to include `select_cohort_full`.
- Modified `FINETUNE_ESTIMATE` pipeline to integrate the new cohort selection component.
- Adjusted paths in configuration and estimation modules to streamline prediction handling.
- Enhanced directory preparation logic to accommodate new calibrated predictions structure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new job type for cohort selection in the Azure environment.

* **Improvements**
  * Simplified and streamlined the FINETUNE_ESTIMATE pipeline, making "meds," "exposures," and "outcomes" required inputs, with "cohort" as the only optional input.
  * Unified pipeline logic for easier use and maintenance.

* **Configuration**
  * Consolidated exposure and outcome prediction paths into a single calibrated predictions directory in configuration files.

* **Bug Fixes**
  * Improved directory checks to support the new consolidated predictions path in setup routines.

* **Other**
  * Enhanced flexibility in handling prediction directory paths within effect estimation modules.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->