### PR TITLE
Try to fix metric plots in azure during pipeline

### DIFF
--- a/corebehrt/azure/util/log.py
+++ b/corebehrt/azure/util/log.py
@@ -80,7 +80,9 @@ def get_run_and_prefix():
     # Check if run has valid info before accessing it
     if run and hasattr(run, "info") and run.info:
         while (parent := mlflow.get_parent_run(run.info.run_id)) is not None:
-            prefix = parent.info.run_name + "/" + prefix
+            run_name = parent.info.run_name
+            if run_name:
+                prefix = run_name + "/" + prefix
             run = parent
 
     return run, prefix
@@ -172,6 +174,8 @@ def log_image(key: str, *args, **kwargs):
         if run is None:
             # Skip logging if no run is active
             return
+        if "artifact_file" in kwargs and prefix:
+            kwargs["artifact_file"] = f"{prefix}/{kwargs['artifact_file']}"
         mlflow.log_image(prefix + key, *args, run_id=run.info.run_id, **kwargs)
 
 
@@ -187,6 +191,8 @@ def log_figure(key: str, *args, **kwargs):
         if run is None:
             # Skip logging if no run is active
             return
+        if "artifact_file" in kwargs and prefix:
+            kwargs["artifact_file"] = f"{prefix}/{kwargs['artifact_file']}"
         mlflow.log_figure(prefix + key, *args, run_id=run.info.run_id, **kwargs)
 
 

--- a/corebehrt/functional/trainer/plotting.py
+++ b/corebehrt/functional/trainer/plotting.py
@@ -9,6 +9,7 @@ import numpy as np
 import pandas as pd
 import torch
 
+from corebehrt.azure.util import log as azure_log
 from corebehrt.constants.causal.data import EXPOSURE
 from corebehrt.functional.visualize.calibrate import plot_probas_hist
 from corebehrt.modules.trainer.causal.utils import CausalPredictionData
@@ -243,6 +244,13 @@ def _create_metric_plot(
     # --- Saving and Closing ---
     try:
         fig.savefig(fig_path, dpi=STYLE_CONFIG["dpi"], bbox_inches="tight")
+        azure_log.log_figure(
+            key=base_metric,
+            figure=fig,
+            artifact_file=f"figs/{group}/{base_metric}.png"
+            if group
+            else f"figs/{base_metric}.png",
+        )
         log_func(f"✅ Plot saved to '{fig_path}'")
     except Exception as e:
         log_func(f"❌ Failed to save plot '{fig_path}'. Error: {e}")


### PR DESCRIPTION
- Updated `get_run_and_prefix` to ensure valid run names are included in the prefix.
- Modified `log_image` and `log_figure` functions to prepend the prefix to the `artifact_file` if specified, improving file organization in logging.

This change enhances the clarity and structure of logged artifacts.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metric plots are now automatically logged to Azure after being saved, with organized artifact paths reflecting plot groups.
* **Bug Fixes**
  * Improved artifact file path handling to prevent empty or incorrect prefixes when logging images or figures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->