### PR TITLE
Improve outcomemaker by writing directly to file, prevent oom error

### DIFF
--- a/corebehrt/main/create_outcomes.py
+++ b/corebehrt/main/create_outcomes.py
@@ -20,7 +20,7 @@ def main_data(config_path):
 
     logger = logging.getLogger("create_outcomes")
     logger.info("Starting outcomes creation")
-    outcome_tables = process_data(
+    process_data(
         ShardLoader(
             data_dir=cfg.paths.data,
             splits=cfg.paths.get("splits", None),
@@ -29,11 +29,6 @@ def main_data(config_path):
         cfg,
         logger,
     )
-
-    for key, df in outcome_tables.items():
-        if df.empty:
-            logger.warning(f"Outcomes table for {key} is empty")
-        df.to_csv(join(cfg.paths.outcomes, f"{key}.csv"), index=False)
 
     logger.info("Finish outcomes creation")
     logger.info("Done")

--- a/corebehrt/main/helper/create_outcomes.py
+++ b/corebehrt/main/helper/create_outcomes.py
@@ -1,7 +1,5 @@
 from collections import defaultdict
-from os.path import join
 
-import pandas as pd
 from tqdm import tqdm
 
 from corebehrt.constants.data import PID_COL
@@ -28,11 +26,11 @@ def process_data(loader, cfg, logger) -> None:
     outcomes_path = cfg.paths.outcomes
     outcome_maker = OutcomeMaker(cfg.outcomes)
 
-    for concept_batch, patient_batch in tqdm(
+    for concept_batch, _ in tqdm(
         loader(), desc="Batch Process Data", file=TqdmToLogger(logger)
     ):
         pids = concept_batch[PID_COL].unique()
-        outcome_maker(concept_batch, patient_batch, pids, outcomes_path, header_written)
+        outcome_maker(concept_batch, pids, outcomes_path, header_written)
 
     for key in cfg.outcomes:
         if not header_written[key]:

--- a/corebehrt/main/helper/create_outcomes.py
+++ b/corebehrt/main/helper/create_outcomes.py
@@ -1,40 +1,39 @@
 from collections import defaultdict
+from os.path import join
 
 import pandas as pd
 from tqdm import tqdm
 
+from corebehrt.constants.data import PID_COL
 from corebehrt.modules.cohort_handling.outcomes import OutcomeMaker
 from corebehrt.modules.monitoring.logger import TqdmToLogger
-from corebehrt.constants.data import PID_COL
 
 
-def process_data(loader, cfg, logger) -> dict:
+def process_data(loader, cfg, logger) -> None:
     """Process batches of concept and patient data to create outcome tables.
+    The outcomes are written to CSV files in an append mode to handle large datasets.
 
     Args:
         loader: A callable that yields tuples of (concept_batch, patient_batch) DataFrames.
-        cfg: Configuration object containing outcome settings.
+        cfg: Configuration object containing outcome settings and paths.
         logger: Logger object for tracking progress.
-
-    Returns:
-        dict: A dictionary mapping outcome names to their corresponding DataFrame tables.
-            Each DataFrame contains the processed outcome data for all patients.
 
     Note:
         The function processes data in batches to handle large datasets efficiently.
         It uses the OutcomeMaker class to generate outcome tables for each batch,
-        then concatenates the results across all batches.
+        then appends the results to CSV files. This avoids holding all outcomes
+        in memory.
     """
-    all_outcomes = defaultdict(list)
+    header_written = defaultdict(bool)
+    outcomes_path = cfg.paths.outcomes
+    outcome_maker = OutcomeMaker(cfg.outcomes)
+
     for concept_batch, patient_batch in tqdm(
         loader(), desc="Batch Process Data", file=TqdmToLogger(logger)
     ):
         pids = concept_batch[PID_COL].unique()
-        outcome_tables = OutcomeMaker(cfg.outcomes)(concept_batch, patient_batch, pids)
-        # Concatenate the tables for each key
-        for key, df in outcome_tables.items():
-            if key in all_outcomes:
-                all_outcomes[key] = pd.concat([all_outcomes[key], df])
-            else:
-                all_outcomes[key] = df
-    return all_outcomes
+        outcome_maker(concept_batch, patient_batch, pids, outcomes_path, header_written)
+
+    for key in cfg.outcomes:
+        if not header_written[key]:
+            logger.warning(f"Outcomes table for {key} is empty. No file was created.")

--- a/corebehrt/modules/cohort_handling/outcomes.py
+++ b/corebehrt/modules/cohort_handling/outcomes.py
@@ -1,4 +1,5 @@
 import logging
+from os.path import join
 from typing import Dict, List
 
 import numpy as np
@@ -41,17 +42,18 @@ class OutcomeMaker:
         concepts_plus: pd.DataFrame,
         patients_info: pd.DataFrame,
         patient_set: List[str],
-    ) -> dict:
-        """Create outcomes from concepts_plus and patients_info"""
+        outcomes_path: str,
+        header_written: Dict[str, bool],
+    ) -> None:
+        """Create outcomes from concepts_plus and patients_info and writes them to disk."""
         # Convert patient IDs to the right type for filtering
         patient_ids = [int(pid) for pid in patient_set]
         concepts_plus = filter_table_by_pids(concepts_plus, patient_ids)
-        patients_info = filter_table_by_pids(patients_info, patient_ids)
+        _ = filter_table_by_pids(patients_info, patient_ids)
         concepts_plus = remove_missing_timestamps(concepts_plus)
         concepts_plus = concepts_plus[
             [PID_COL, TIMESTAMP_COL, CONCEPT_COL, VALUE_COL]
         ]  # get only relevant columns
-        outcome_tables = {}
         for outcome, attrs in self.outcomes.items():
             # Handle combination outcomes
             if COMBINATIONS in attrs:
@@ -69,15 +71,21 @@ class OutcomeMaker:
                 )
 
             # Only process if we have data
-            if len(timestamps) > 0:
+            if not timestamps.empty:
                 if ABSPOS_COL not in timestamps.columns:
                     timestamps[ABSPOS_COL] = get_hours_since_epoch(
                         timestamps[TIMESTAMP_COL]
                     )
                 timestamps[ABSPOS_COL] = timestamps[ABSPOS_COL].astype(int)
                 timestamps[PID_COL] = timestamps[PID_COL].astype(int)
-            outcome_tables[outcome] = timestamps
-        return outcome_tables
+
+                output_path = join(outcomes_path, f"{outcome}.csv")
+                write_header = not header_written[outcome]
+                timestamps.to_csv(
+                    output_path, mode="a", header=write_header, index=False
+                )
+                if write_header:
+                    header_written[outcome] = True
 
     def match_concepts(
         self,

--- a/corebehrt/modules/cohort_handling/outcomes.py
+++ b/corebehrt/modules/cohort_handling/outcomes.py
@@ -49,7 +49,6 @@ class OutcomeMaker:
         # Convert patient IDs to the right type for filtering
         patient_ids = [int(pid) for pid in patient_set]
         concepts_plus = filter_table_by_pids(concepts_plus, patient_ids)
-        _ = filter_table_by_pids(patients_info, patient_ids)
         concepts_plus = remove_missing_timestamps(concepts_plus)
         concepts_plus = concepts_plus[
             [PID_COL, TIMESTAMP_COL, CONCEPT_COL, VALUE_COL]

--- a/corebehrt/modules/cohort_handling/outcomes.py
+++ b/corebehrt/modules/cohort_handling/outcomes.py
@@ -40,7 +40,6 @@ class OutcomeMaker:
     def __call__(
         self,
         concepts_plus: pd.DataFrame,
-        patients_info: pd.DataFrame,
         patient_set: List[str],
         outcomes_path: str,
         header_written: Dict[str, bool],

--- a/tests/test_modules/test_outcomemaker.py
+++ b/tests/test_modules/test_outcomemaker.py
@@ -122,13 +122,6 @@ class TestOutcomeMaker(unittest.TestCase):
             [self.concepts_plus, exclusion_data], ignore_index=True
         )
 
-        # Create patient info data
-        self.patients_info = pd.DataFrame(
-            {
-                PID_COL: [1, 2, 3, 4, 5, 6, 7, 8, 9],
-            }
-        )
-
         # Patient set for testing
         self.patient_set = [1, 2, 3, 4, 5, 6, 7, 8, 9]
 
@@ -154,7 +147,6 @@ class TestOutcomeMaker(unittest.TestCase):
         # Get outcomes
         outcome_maker(
             self.concepts_plus,
-            self.patients_info,
             self.patient_set,
             self.outcomes_path,
             header_written,
@@ -204,7 +196,6 @@ class TestOutcomeMaker(unittest.TestCase):
         # Get outcomes
         outcome_maker(
             self.concepts_plus,
-            self.patients_info,
             self.patient_set,
             self.outcomes_path,
             header_written,
@@ -246,7 +237,6 @@ class TestOutcomeMaker(unittest.TestCase):
         # Get outcomes
         outcome_maker(
             self.concepts_plus,
-            self.patients_info,
             self.patient_set,
             self.outcomes_path,
             header_written,
@@ -303,7 +293,6 @@ class TestOutcomeMaker(unittest.TestCase):
         # Get outcomes
         outcome_maker(
             self.concepts_plus,
-            self.patients_info,
             self.patient_set,
             self.outcomes_path,
             header_written,
@@ -354,7 +343,6 @@ class TestOutcomeMaker(unittest.TestCase):
         # Get outcomes
         outcome_maker(
             self.concepts_plus,
-            self.patients_info,
             self.patient_set,
             self.outcomes_path,
             header_written,
@@ -410,7 +398,6 @@ class TestOutcomeMaker(unittest.TestCase):
         # Get outcomes
         outcome_maker(
             self.concepts_plus,
-            self.patients_info,
             self.patient_set,
             self.outcomes_path,
             header_written,
@@ -460,7 +447,6 @@ class TestOutcomeMaker(unittest.TestCase):
         # Get outcomes
         outcome_maker(
             self.concepts_plus,
-            self.patients_info,
             self.patient_set,
             self.outcomes_path,
             header_written,
@@ -505,7 +491,6 @@ class TestOutcomeMaker(unittest.TestCase):
         # Get outcomes
         outcome_maker(
             self.concepts_plus,
-            self.patients_info,
             self.patient_set,
             self.outcomes_path,
             header_written,
@@ -547,7 +532,6 @@ class TestOutcomeMaker(unittest.TestCase):
         header_written = defaultdict(bool)
         outcome_maker(
             self.concepts_plus,
-            self.patients_info,
             self.patient_set,
             self.outcomes_path,
             header_written,

--- a/tests/test_modules/test_outcomemaker.py
+++ b/tests/test_modules/test_outcomemaker.py
@@ -454,8 +454,16 @@ class TestOutcomeMaker(unittest.TestCase):
 
         # Check result
         output_file = os.path.join(self.outcomes_path, "IMPOSSIBLE_COMBINATION.csv")
-        # Should not create a file for empty results
-        self.assertFalse(os.path.exists(output_file))
+        # Should create a file even for empty results
+        self.assertTrue(os.path.exists(output_file))
+        empty_outcome = pd.read_csv(output_file)
+        self.assertEqual(len(empty_outcome), 0)
+        self.assertTrue(
+            all(
+                col in empty_outcome.columns
+                for col in [PID_COL, TIMESTAMP_COL, ABSPOS_COL]
+            )
+        )
 
     def test_multiple_outcomes_together(self):
         """Test handling multiple outcome types in the same call"""
@@ -496,15 +504,17 @@ class TestOutcomeMaker(unittest.TestCase):
             header_written,
         )
 
-        # Check result - only outcomes with matches should produce files
+        # Check result - all outcome types should produce files
         basic_file = os.path.join(self.outcomes_path, "BASIC_OUTCOME.csv")
         combo_file = os.path.join(self.outcomes_path, "COMBINATION_OUTCOME.csv")
 
         self.assertTrue(os.path.exists(basic_file))
-        self.assertFalse(os.path.exists(combo_file))
+        self.assertTrue(os.path.exists(combo_file))
 
         basic_outcome = pd.read_csv(basic_file)
         self.assertEqual(len(basic_outcome), 3)
+        combo_outcome = pd.read_csv(combo_file)
+        self.assertEqual(len(combo_outcome), 0)
 
     def test_exclusion_non_fatal_mi(self):
         """Test exclusion of events that are followed by death within a week."""


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Outcome data is now written directly to CSV files during processing, rather than being accumulated in memory.
  * Output files are managed to ensure headers are written only once, and empty outcomes result in empty CSVs with headers.
  * The process has shifted to batch processing with immediate file output, improving memory efficiency.

* **Tests**
  * Updated tests to verify outcome data by reading generated CSV files instead of checking in-memory results.
  * Added cleanup for temporary files after tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->